### PR TITLE
Add NextAuth login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXTAUTH_SECRET=changeme
+#NEXTAUTH_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ pnpm dev
 bun dev
 ```
 
+### Environment variables
+
+Create a `.env.local` file based on `.env.example` and set `NEXTAUTH_SECRET`.
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from "next-auth"
+import { authOptions } from "@/lib/auth"
+
+const handler = NextAuth(authOptions)
+
+export { handler as GET, handler as POST }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Navbar } from "@/components/navbar";
+import { Providers } from "@/components/providers";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -24,11 +25,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        <Navbar></Navbar>
-        {children}
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <Providers>
+          <Navbar />
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,13 @@
 import { LoginForm } from "@/components/login-form"
+import { getServerSession } from "next-auth"
+import { authOptions } from "@/lib/auth"
+import { redirect } from "next/navigation"
 
-export default function LoginPage() {
+export default async function LoginPage() {
+  const session = await getServerSession(authOptions)
+  if (session) {
+    redirect("/dashboard")
+  }
   return (
     <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
       <div className="w-full max-w-md">

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -3,6 +3,8 @@
 import type React from "react"
 
 import { useState } from "react"
+import { signIn } from "next-auth/react"
+import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -18,18 +20,25 @@ export function LoginForm() {
   const [password, setPassword] = useState("")
   const [showPassword, setShowPassword] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  const router = useRouter()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsLoading(true)
 
-    // Simulate login process
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-
-    console.log("Login attempt:", { userType, email, password })
-    alert(`Iniciando sesión como ${userType === "foodie" ? "Foodie" : "Restaurante"}`)
+    const res = await signIn("credentials", {
+      redirect: false,
+      email,
+      password,
+    })
 
     setIsLoading(false)
+
+    if (!res?.error) {
+      router.push("/dashboard")
+    } else {
+      alert("Credenciales inválidas")
+    }
   }
 
   return (

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -2,11 +2,13 @@
 
 import Link from "next/link"
 import { useState } from "react"
+import { useSession, signOut } from "next-auth/react"
 import { Button } from "@/components/ui/button"
 import { Menu, X, User } from "lucide-react"
 
 export function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const { data: session } = useSession()
 
   const toggleMenu = () => {
     setIsMenuOpen(!isMenuOpen)
@@ -50,16 +52,27 @@ export function Navbar() {
               >
                 Dashboard
               </Link>
-              <Link href="/login">
+              {session ? (
                 <Button
                   variant="outline"
                   size="sm"
+                  onClick={() => signOut({ callbackUrl: "/" })}
                   className="border-red-500 text-red-500 hover:bg-red-500 hover:text-white transition-colors bg-transparent"
                 >
-                  <User className="h-4 w-4 mr-2" />
-                  Iniciar Sesión
+                  Cerrar Sesión
                 </Button>
-              </Link>
+              ) : (
+                <Link href="/login">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="border-red-500 text-red-500 hover:bg-red-500 hover:text-white transition-colors bg-transparent"
+                  >
+                    <User className="h-4 w-4 mr-2" />
+                    Iniciar Sesión
+                  </Button>
+                </Link>
+              )}
             </div>
           </div>
 
@@ -101,16 +114,30 @@ export function Navbar() {
               Cómo Funciona
             </Link>
             <div className="px-3 py-2">
-              <Link href="/login" onClick={() => setIsMenuOpen(false)}>
+              {session ? (
                 <Button
                   variant="outline"
                   size="sm"
+                  onClick={() => {
+                    setIsMenuOpen(false)
+                    signOut({ callbackUrl: "/" })
+                  }}
                   className="w-full border-red-500 text-red-500 hover:bg-red-500 hover:text-white transition-colors bg-transparent"
                 >
-                  <User className="h-4 w-4 mr-2" />
-                  Iniciar Sesión
+                  Cerrar Sesión
                 </Button>
-              </Link>
+              ) : (
+                <Link href="/login" onClick={() => setIsMenuOpen(false)}>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-full border-red-500 text-red-500 hover:bg-red-500 hover:text-white transition-colors bg-transparent"
+                  >
+                    <User className="h-4 w-4 mr-2" />
+                    Iniciar Sesión
+                  </Button>
+                </Link>
+              )}
             </div>
           </div>
         </div>

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { SessionProvider } from "next-auth/react"
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,28 @@
+import type { NextAuthOptions } from "next-auth"
+import CredentialsProvider from "next-auth/providers/credentials"
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    CredentialsProvider({
+      name: "Credentials",
+      credentials: {
+        email: { label: "Email", type: "text" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        const user = { id: "1", name: "Demo User", email: "demo@foodies.com" }
+        if (
+          credentials?.email === user.email &&
+          credentials?.password === "password"
+        ) {
+          return user
+        }
+        return null
+      },
+    }),
+  ],
+  session: { strategy: "jwt" },
+  pages: {
+    signIn: "/login",
+  },
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react": "^19.0.0",
     "react-day-picker": "^9.7.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "next-auth": "^4.24.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- add NextAuth dependency and example env file
- configure auth options with credentials provider
- expose auth API route
- wrap app with SessionProvider
- integrate sign-in/sign-out in Navbar
- update login form to use NextAuth
- redirect logged users from login page
- document env variables

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_685f871421a48325bd0466e754c912ec